### PR TITLE
Clear diagnostics when document was closed

### DIFF
--- a/lib/rucoa/handler_concerns/diagnostics_publishable.rb
+++ b/lib/rucoa/handler_concerns/diagnostics_publishable.rb
@@ -18,6 +18,18 @@ module Rucoa
 
       # @param uri [String]
       # @return [void]
+      def clear_diagnostics_on(uri)
+        write(
+          method: 'textDocument/publishDiagnostics',
+          params: {
+            diagnostics: [],
+            uri: uri
+          }
+        )
+      end
+
+      # @param uri [String]
+      # @return [void]
       def publish_diagnostics_on(uri)
         write(
           method: 'textDocument/publishDiagnostics',

--- a/lib/rucoa/handlers.rb
+++ b/lib/rucoa/handlers.rb
@@ -10,6 +10,7 @@ module Rucoa
     autoload :TextDocumentCodeActionHandler, 'rucoa/handlers/text_document_code_action_handler'
     autoload :TextDocumentCompletionHandler, 'rucoa/handlers/text_document_completion_handler'
     autoload :TextDocumentDidChangeHandler, 'rucoa/handlers/text_document_did_change_handler'
+    autoload :TextDocumentDidCloseHandler, 'rucoa/handlers/text_document_did_close_handler'
     autoload :TextDocumentDidOpenHandler, 'rucoa/handlers/text_document_did_open_handler'
     autoload :TextDocumentDocumentSymbolHandler, 'rucoa/handlers/text_document_document_symbol_handler'
     autoload :TextDocumentFormattingHandler, 'rucoa/handlers/text_document_formatting_handler'

--- a/lib/rucoa/handlers/text_document_did_close_handler.rb
+++ b/lib/rucoa/handlers/text_document_did_close_handler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Rucoa
+  module Handlers
+    class TextDocumentDidCloseHandler < Base
+      include HandlerConcerns::DiagnosticsPublishable
+
+      def call
+        clear_diagnostics_on(uri)
+      end
+
+      private
+
+      # @return [String]
+      def uri
+        request.dig('params', 'textDocument', 'uri')
+      end
+    end
+  end
+end

--- a/lib/rucoa/server.rb
+++ b/lib/rucoa/server.rb
@@ -14,6 +14,7 @@ module Rucoa
       'textDocument/codeAction' => Handlers::TextDocumentCodeActionHandler,
       'textDocument/completion' => Handlers::TextDocumentCompletionHandler,
       'textDocument/didChange' => Handlers::TextDocumentDidChangeHandler,
+      'textDocument/didClose' => Handlers::TextDocumentDidCloseHandler,
       'textDocument/didOpen' => Handlers::TextDocumentDidOpenHandler,
       'textDocument/documentSymbol' => Handlers::TextDocumentDocumentSymbolHandler,
       'textDocument/formatting' => Handlers::TextDocumentFormattingHandler,

--- a/spec/rucoa/handlers/text_document_did_close_handler_spec.rb
+++ b/spec/rucoa/handlers/text_document_did_close_handler_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Rucoa::Handlers::TextDocumentDidCloseHandler do
+  describe '.call' do
+    subject do
+      described_class.call(
+        request: request,
+        server: server
+      )
+    end
+
+    let(:request) do
+      {
+        'id' => 1,
+        'method' => 'textDocument/didClose',
+        'params' => {
+          'textDocument' => {
+            'uri' => uri
+          }
+        }
+      }
+    end
+
+    let(:server) do
+      Rucoa::Server.new
+    end
+
+    let(:uri) do
+      'file://example.rb'
+    end
+
+    shared_examples 'publishes empty diagnostics' do
+      it 'publishes empty diagnostics' do
+        subject
+        expect(server.responses).to match(
+          [
+            {
+              'jsonrpc' => '2.0',
+              'method' => 'textDocument/publishDiagnostics',
+              'params' => {
+                'diagnostics' => [],
+                'uri' => uri
+              }
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with valid condition' do
+      include_examples 'publishes empty diagnostics'
+    end
+  end
+end


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/111689/190053031-c77e8fb2-928b-4042-8f08-162c6e2f487b.png)

so that no items are left in the problems tab on VS Code.
