### PR TITLE
Assign default column and line values to `Rucoa::Position#initialize`

### DIFF
--- a/lib/rucoa/position.rb
+++ b/lib/rucoa/position.rb
@@ -39,7 +39,7 @@ module Rucoa
 
     # @param column [Integer] 0-origin column number
     # @param line [Integer] 1-origin line number
-    def initialize(column:, line:)
+    def initialize(column: 0, line: 1)
       @column = column
       @line = line
     end


### PR DESCRIPTION
It's good in the sense that it can explain their radixes, and also be useful when we want to point to the start poisiton of a source file.
